### PR TITLE
Bugfix - Mounting devices on subfolders does not work

### DIFF
--- a/archvyrt/provisioner/archlinux.py
+++ b/archvyrt/provisioner/archlinux.py
@@ -150,7 +150,7 @@ class ArchlinuxProvisioner(Base):
                         ])
                 else:
                     # create mountpoint
-                    os.mkdir(mountpoint)
+                    os.makedirs(mountpoint)
                 self.run([
                     '/usr/bin/mount',
                     '%sp%d' % (dev, cur_part),


### PR DESCRIPTION
If you want to mount a disk to a subfolder you will get an error due to
to non-recursive mkdir command used.
This bugfix changes the command to use the recursive makedirs command
that will also create all parent directories
